### PR TITLE
Add support for the label image attribute as per the iOS version.

### DIFF
--- a/TabbedBar/TabbedBar.js
+++ b/TabbedBar/TabbedBar.js
@@ -92,7 +92,10 @@ module.exports = (function () {
 	        for (var i = 0; i < barLabels.length; i++) {
 	            var button = Ti.UI.createButton({
 	                bubbleParent: false,
-	                title: (typeof barLabels[i] == 'string') ? barLabels[i] : barLabels[i].title,
+	                // Don't use title if an image is set.
+	                title: (typeof barLabels[i].image !== "undefined") ? "" : (typeof barLabels[i] == "string") ? barLabels[i] : barLabels[i].title,
+	                // Add a backgroundImage if image is set.
+	                backgroundImage: (typeof barLabels[i].image !== "undefined") ? barLabels[i].image : "",
 	                height: "100%",
 	                width: 100 / barLabels.length + "%",
 	                backgroundColor: barBackgroundColor,


### PR DESCRIPTION
This commit makes the label image attribute work as per the iOS one.

See http://docs.appcelerator.com/titanium/3.0/#!/api/BarItemType or the labels property at http://docs.appcelerator.com/titanium/3.0/#!/api/Titanium.UI.iOS.TabbedBar

If you prefer to to have multiple ternary operators on a single line, as used for title I can change it.
