### PR TITLE
Add support for label width property as per the iOS version.

### DIFF
--- a/TabbedBar/TabbedBar.js
+++ b/TabbedBar/TabbedBar.js
@@ -94,7 +94,11 @@ module.exports = (function () {
 	                bubbleParent: false,
 	                title: (typeof barLabels[i] == 'string') ? barLabels[i] : barLabels[i].title,
 	                height: "100%",
-	                width: 100 / barLabels.length + "%",
+	                // If label width is set use that, otherwise evenly divide
+	                // the bar based on the number of labels. This may cause
+	                // issues if a width is set on some labels but not all labels
+	                // but it is up to the developer to not do that.
+	                width: (typeof barLabels[i].width !== "undefined") ? barLabels[i].width : 100 / barLabels.length + "%",
 	                backgroundColor: barBackgroundColor,
 	                color: barTextColor,
 	                font: barTextFont,


### PR DESCRIPTION
The titanium iOS version of tabbed bar supports a width property for labels but this one doesn't.

This commit adds support for that label width.

If you prefer, more effort could be put into the case where a developer only specifies a width on some, but not all, labels of a tabbed bar, but for now I have made it so you really need to have widths for all or none.

See http://docs.appcelerator.com/titanium/3.0/#!/api/BarItemType and the labels property at http://docs.appcelerator.com/titanium/3.0/#!/api/Titanium.UI.iOS.TabbedBar
