### PR TITLE
Update TabbedBar.js

### DIFF
--- a/TabbedBar/TabbedBar.js
+++ b/TabbedBar/TabbedBar.js
@@ -71,7 +71,7 @@ module.exports = (function () {
             borderRadius: _toDp(2.5),
             borderWidth: barBorderWidth,
             borderColor: barTintColor,
-            layout: (typeof barLabels[i].width !== "undefined") ? "horizontal" ? null,
+            layout: (typeof barLabels[i].width == "undefined") ? "horizontal" ? null,
         });
 
         //passing positioning data to the view


### PR DESCRIPTION
Occasionally the total tab/button width exceeds that of the bar width, forcing the last tab to a new line, out of the tab's viewport.

If a bar width is specified, do not use a `horizontal` bar layout, instead set the `left` property of each tab to ensure all tabs always remain in the bar's viewport.
