### PR TITLE
Fix for iOS 10 changing Ti.Platform.name to "iOS"

### DIFF
--- a/TabbedBar/TabbedBar.js
+++ b/TabbedBar/TabbedBar.js
@@ -19,6 +19,7 @@ module.exports = (function () {
     //since the options are compatible with the native iOS tabbed bar, only use the custom bar when the platform isn't iOS
     switch (Ti.Platform.name) {
     case "iPhone OS":
+    case "iOS":
         return {
             createTabbedBar: function (options) {
                 return Ti.UI.iOS.createTabbedBar(options);


### PR DESCRIPTION
Things didn't seem to work right when I updated to the latest version of the SDK (6.3.0.GA), and it turned out that the switch statement was going down the wrong path for iOS because Ti.Platform.name no longer returns "iPhone OS" but "iOS".